### PR TITLE
`old-time` to `time`

### DIFF
--- a/diagrams-cairo.cabal
+++ b/diagrams-cairo.cabal
@@ -45,6 +45,7 @@ Library
                        directory,
                        filepath,
                        old-time,
+                       time,
                        diagrams-core >= 0.6 && < 0.7,
                        diagrams-lib >= 0.6 && < 0.7,
                        cairo >= 0.10.1 && < 0.13,


### PR DESCRIPTION
Fix issue cause by directory switching from old-time to time with 7.6.
This follows what was done for `diagrams-svg` and fixes #21.
