### PR TITLE
use new pathTrail Iso lens

### DIFF
--- a/diagrams-cairo.cabal
+++ b/diagrams-cairo.cabal
@@ -57,10 +57,11 @@ Library
                        time,
                        diagrams-core >= 0.7 && < 0.8,
                        diagrams-lib >= 0.7 && < 0.8,
-                       cairo >= 0.12.4 && < 0.13,
+                       cairo >= 0.12 && < 0.13,
                        cmdargs >= 0.6 && < 0.11,
                        colour,
-                       split >= 0.1.2 && < 0.3
+                       split >= 0.1.2 && < 0.3,
+                       lens >= 3.8 && < 4
   default-language:    Haskell2010
 
   if !os(windows)

--- a/src/Diagrams/Backend/Cairo/Internal.hs
+++ b/src/Diagrams/Backend/Cairo/Internal.hs
@@ -54,6 +54,7 @@ import           Data.List                       (isSuffixOf)
 import           Data.Maybe                      (catMaybes, fromMaybe)
 
 import           Control.Exception               (try)
+import           Control.Lens                    hiding ((#))
 
 import qualified Data.Foldable                   as F
 
@@ -279,7 +280,7 @@ instance Renderable (Trail R2) Cairo where
             -- remember that we saw a Line, so we will ignore fill attribute
 
 instance Renderable (Path R2) Cairo where
-  render _ (Path trs) = C $ lift C.newPath >> F.mapM_ renderTrail trs
+  render _ trs = C $ lift C.newPath >> F.mapM_ renderTrail (trs^.pathTrails)
     where renderTrail (viewLoc -> (unp2 -> p, tr)) = do
             lift $ uncurry C.moveTo p
             renderC tr


### PR DESCRIPTION
This patch allows diagrams-cairo to build against diagrams-lib HEAD.  I would push this to master myself, except I want to confirm the convention used.  

When we switch to lenses and stop exporting constructors, we prohibit the ugly `_pathTrails trs` expression, but also prohibit the pattern match `(Path trs)`.  @byorgey, is this what @jeffreyrosenbluth and I should do consistently?
