### PR TITLE
port to linear instead of vector-space

### DIFF
--- a/src/Diagrams/Backend/Cairo.hs
+++ b/src/Diagrams/Backend/Cairo.hs
@@ -29,13 +29,14 @@
 -- > renderDia :: b -> Options b v -> QDiagram b v m -> Result b v
 --
 -- (omitting a few type class constraints).  @b@ represents the
--- backend type, @v@ the vector space, and @m@ the type of monoidal
--- query annotations on the diagram.  'Options' and 'Result' are
--- associated data and type families, respectively, which yield the
--- type of option records and rendering results specific to any
--- particular backend.  For @b ~ Cairo@ and @v ~ R2@, we have
+-- backend type, @v@ the vector space, @n@ the numeric field, and @m@
+-- the type of monoidal query annotations on the diagram.  'Options'
+-- and 'Result' are associated data and type families, respectively,
+-- which yield the type of option records and rendering results
+-- specific to any particular backend.  For @b ~ Cairo@ @n ~ Double@,
+-- and @v ~ V2@, we have
 --
--- > data family Options Cairo R2 = CairoOptions
+-- > data family Options Cairo V2 Double = CairoOptions
 -- >          { _cairoFileName     :: String     -- ^ The name of the file you want generated
 -- >          , _cairoSizeSpec     :: SizeSpec2D -- ^ The requested size of the output
 -- >          , _cairoOutputType   :: OutputType -- ^ the output format and associated options
@@ -43,19 +44,19 @@
 -- >          }
 --
 -- @
--- type family Result Cairo R2 = (IO (), 'Graphics.Rendering.Cairo.Render' ())
+-- type family Result Cairo V2 Double = (IO (), 'Graphics.Rendering.Cairo.Render' ())
 -- @
 --
 -- So the type of 'renderDia' resolves to
 --
 -- @
--- renderDia :: Cairo -> Options Cairo R2 -> QDiagram Cairo R2 m -> (IO (), 'Graphics.Rendering.Cairo.Render' ())
+-- renderDia :: Cairo -> Options Cairo V2 Double -> QDiagram Cairo V2 Double m -> (IO (), 'Graphics.Rendering.Cairo.Render' ())
 -- @
 --
 -- which you could call like so:
 --
 -- @
--- renderDia Cairo (CairoOptions \"foo.png\" (Width 250) PNG False) (myDiagram :: Diagram Cairo R2)
+-- renderDia Cairo (CairoOptions \"foo.png\" (Width 250) PNG False) (myDiagram :: Diagram Cairo V2 Double)
 -- @
 --
 -- This would return a pair; the first element is an @IO ()@ action
@@ -106,7 +107,7 @@ import Diagrams.Prelude
 -- associated data families, so we must just provide it manually.
 -- This module defines
 --
--- > data family Options Cairo R2 = CairoOptions
+-- > data family Options Cairo V2 Double = CairoOptions
 -- >           { _cairoFileName   :: String     -- ^ The name of the file you want generated
 -- >           , _cairoSizeSpec   :: SizeSpec2D -- ^ The requested size of the output
 -- >           , _cairoOutputType :: OutputType -- ^ the output format and associated options
@@ -129,7 +130,7 @@ import Diagrams.Prelude
 --   This function is provided as a convenience; if you need more
 --   flexibility than it provides, you can call 'renderDia' directly,
 --   as described above.
-renderCairo :: FilePath -> SizeSpec2D -> Diagram Cairo R2 -> IO ()
+renderCairo :: FilePath -> SizeSpec2D Double -> Diagram Cairo V2 Double -> IO ()
 renderCairo outFile sizeSpec d
   = fst (renderDia Cairo (CairoOptions outFile sizeSpec outTy False) d)
   where

--- a/src/Diagrams/Backend/Cairo/CmdLine.hs
+++ b/src/Diagrams/Backend/Cairo/CmdLine.hs
@@ -115,7 +115,7 @@ import           Data.List.Split
 -- will produce a program that looks for additional number and color arguments.
 --
 -- > ... definitions ...
--- > f :: Int -> Colour Double -> Diagram Cairo R2
+-- > f :: Int -> Colour Double -> Diagram Cairo V2 Double
 -- > f i c = ...
 -- >
 -- > main = mainWith f
@@ -177,15 +177,15 @@ import           Data.List.Split
 -- $ ./MyDiagram -o dia.pdf -h 200 -w 200 -l -i 10
 -- @
 
-defaultMain :: Diagram Cairo R2 -> IO ()
+defaultMain :: Diagram Cairo V2 Double -> IO ()
 defaultMain = mainWith
 
-instance Mainable (Diagram Cairo R2) where
-    type MainOpts (Diagram Cairo R2) = (DiagramOpts, DiagramLoopOpts)
+instance Mainable (Diagram Cairo V2 Double) where
+    type MainOpts (Diagram Cairo V2 Double) = (DiagramOpts, DiagramLoopOpts)
 
     mainRender (opts, l) d = chooseRender opts d >> defaultLoopRender l
 
-chooseRender :: DiagramOpts -> Diagram Cairo R2 -> IO ()
+chooseRender :: DiagramOpts -> Diagram Cairo V2 Double -> IO ()
 chooseRender opts d =
   case splitOn "." (opts ^. output) of
     [""] -> putStrLn "No output file given."
@@ -229,12 +229,12 @@ chooseRender opts d =
 -- $ ./MultiTest --selection bar -o Bar.png -w 200
 -- @
 
-multiMain :: [(String, Diagram Cairo R2)] -> IO ()
+multiMain :: [(String, Diagram Cairo V2 Double)] -> IO ()
 multiMain = mainWith
 
-instance Mainable [(String, Diagram Cairo R2)] where
-    type MainOpts [(String, Diagram Cairo R2)]
-        = (MainOpts (Diagram Cairo R2), DiagramMultiOpts)
+instance Mainable [(String, Diagram Cairo V2 Double)] where
+    type MainOpts [(String, Diagram Cairo V2 Double)]
+        = (MainOpts (Diagram Cairo V2 Double), DiagramMultiOpts)
 
     mainRender = defaultMultiMainRender
 
@@ -254,11 +254,11 @@ instance Mainable [(String, Diagram Cairo R2)] where
 --
 -- The @--fpu@ option can be used to control how many frames will be
 -- output for each second (unit time) of animation.
-animMain :: Animation Cairo R2 -> IO ()
+animMain :: Animation Cairo V2 Double -> IO ()
 animMain = mainWith
 
-instance Mainable (Animation Cairo R2) where
-    type MainOpts (Animation Cairo R2) = ((DiagramOpts, DiagramAnimOpts), DiagramLoopOpts)
+instance Mainable (Animation Cairo V2 Double) where
+    type MainOpts (Animation Cairo V2 Double) = ((DiagramOpts, DiagramAnimOpts), DiagramLoopOpts)
 
     mainRender (opts, l) d =  defaultAnimMainRender chooseRender output opts d >> defaultLoopRender l
 
@@ -288,7 +288,7 @@ instance Mainable (Animation Cairo R2) where
 --    --looping-off            Turn looping off
 --    --loop-repeat ARG        Number of times to repeat
 -- @
-gifMain :: [(Diagram Cairo R2, GifDelay)] -> IO ()
+gifMain :: [(Diagram Cairo V2 Double, GifDelay)] -> IO ()
 gifMain = mainWith
 
 -- | Extra options for animated GIFs.
@@ -314,8 +314,8 @@ instance Parseable GifOpts where
                        ( long "loop-repeat"
                       <> help "Number of times to repeat" )
 
-instance Mainable [(Diagram Cairo R2, GifDelay)] where
-    type MainOpts [(Diagram Cairo R2, GifDelay)] = (DiagramOpts, GifOpts)
+instance Mainable [(Diagram Cairo V2 Double, GifDelay)] where
+    type MainOpts [(Diagram Cairo V2 Double, GifDelay)] = (DiagramOpts, GifOpts)
 
     mainRender (dOpts, gOpts) ds = gifRender (dOpts, gOpts) ds
 
@@ -346,7 +346,7 @@ scaleInt i num denom
   | num == 0 || denom == 0 = i
   | otherwise = round (num / denom * fromIntegral i)
 
-gifRender :: (DiagramOpts, GifOpts) -> [(Diagram Cairo R2, GifDelay)] -> IO ()
+gifRender :: (DiagramOpts, GifOpts) -> [(Diagram Cairo V2 Double, GifDelay)] -> IO ()
 gifRender (dOpts, gOpts) lst =
   case splitOn "." (dOpts^.output) of
     [""] -> putStrLn "No output file given"

--- a/src/Diagrams/Backend/Cairo/List.hs
+++ b/src/Diagrams/Backend/Cairo/List.hs
@@ -1,4 +1,3 @@
-
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Diagrams.Backend.Cairo.List
@@ -23,7 +22,7 @@ import           Data.Word                  (Word8)
 import           Diagrams.Backend.Cairo     (Cairo)
 import           Diagrams.Backend.Cairo.Ptr (renderPtr)
 import           Graphics.Rendering.Cairo   (Format (..))
-import           Diagrams.Prelude           (Diagram, R2)
+import           Diagrams.Prelude           (Diagram, V2)
 
 import           Foreign.Marshal.Alloc      (free)
 import           Foreign.Marshal.Array      (peekArray)
@@ -31,7 +30,7 @@ import           Foreign.Marshal.Array      (peekArray)
 -- | Render to a regular list of Colour values.
 
 renderToList :: (Ord a, Floating a) =>
-                  Int -> Int -> Diagram Cairo R2 -> IO [[AlphaColour a]]
+                  Int -> Int -> Diagram Cairo V2 Double -> IO [[AlphaColour a]]
 renderToList w h d =
   f 0 <$> bracket (renderPtr w h FormatARGB32 d) free (peekArray $ w*h*4)
  where

--- a/src/Diagrams/Backend/Cairo/Ptr.hs
+++ b/src/Diagrams/Backend/Cairo/Ptr.hs
@@ -1,4 +1,3 @@
-
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Diagrams.Backend.Cairo.Ptr
@@ -14,7 +13,7 @@ module Diagrams.Backend.Cairo.Ptr where
 
 import Data.Word (Word8)
 
-import Diagrams.Prelude (Diagram, R2, SizeSpec2D (..), renderDia)
+import Diagrams.Prelude (Diagram, V2, SizeSpec2D (..), renderDia)
 import Diagrams.Backend.Cairo
 import Diagrams.Backend.Cairo.Internal
 
@@ -31,7 +30,7 @@ import Graphics.Rendering.Cairo ( Format (..)
 
 -- | Render a diagram to a new buffer in memory, with the format ARGB32.
 
-renderPtr :: Int -> Int -> Format -> Diagram Cairo R2 -> IO (Ptr Word8)
+renderPtr :: Int -> Int -> Format -> Diagram Cairo V2 Double -> IO (Ptr Word8)
 renderPtr w h fmt d = do
   let stride = formatStrideForWidth fmt w
       size   = stride * h
@@ -51,8 +50,8 @@ renderPtr w h fmt d = do
 
 -- | Like 'renderPtr' but automatically garbage collected by Haskell.
 
-renderForeignPtr :: Int -> Int -> Diagram Cairo R2 -> IO (ForeignPtr Word8)
+renderForeignPtr :: Int -> Int -> Diagram Cairo V2 Double -> IO (ForeignPtr Word8)
 renderForeignPtr w h d = renderPtr w h FormatARGB32 d >>= newForeignPtr finalizerFree
 
-renderForeignPtrOpaque :: Int -> Int -> Diagram Cairo R2 -> IO (ForeignPtr Word8)
+renderForeignPtrOpaque :: Int -> Int -> Diagram Cairo V2 Double -> IO (ForeignPtr Word8)
 renderForeignPtrOpaque w h d = renderPtr w h FormatRGB24 d >>= newForeignPtr finalizerFree

--- a/test/BezParam.hs
+++ b/test/BezParam.hs
@@ -4,15 +4,15 @@ import Diagrams.Prelude
 
 import Diagrams.Backend.Cairo.CmdLine
 
-type D = Diagram Cairo R2
+type D = Diagram Cairo V2 Double
 
-t :: Trail R2
+t :: Trail V2 Double
 t = (polygonPath with {sides = 3, orientation = OrientToX})
 [v1,v2] = trailOffsets t
 
 seg = Cubic v1 v1 (v1 ^+^ v2)
 
-s :: Trail R2
+s :: Trail V2 Double
 s = fromSegments [seg]
 
 pts = map ((origin .+^) . (seg `atParam`)) [0,0.01..1]

--- a/test/Bounds.hs
+++ b/test/Bounds.hs
@@ -3,4 +3,4 @@
 import Diagrams.Prelude
 import Diagrams.Backend.Cairo.CmdLine
 
-main = defaultMain (circle 4 # withBounds (getBounds (unitSquare :: Diagram Cairo R2)))
+main = defaultMain (circle 4 # withBounds (getBounds (unitSquare :: Diagram Cairo V2 Double)))

--- a/test/BoundsTest.hs
+++ b/test/BoundsTest.hs
@@ -4,7 +4,7 @@ import Diagrams.Prelude
 
 import Diagrams.Backend.Cairo.CmdLine
 
-type D = Diagram Cairo R2
+type D = Diagram Cairo V2 Double
 
 p, bez, ell :: D
 p = stroke $ fromSegments [Linear (1.0,0.0),Linear (0.0,1.0)]
@@ -14,7 +14,7 @@ ell = scaleX 2 $ scaleY 0.5 unitCircle
 t = (polygonPath with {sides = 3, orientation = OrientToX})
 [v1,v2] = trailOffsets t
 
-s :: Trail R2
+s :: Trail V2 Double
 s = fromSegments [Cubic v1 v1 (v1 ^+^ v2)]
 
 s1 = (strokeT $ s)

--- a/test/Clip.hs
+++ b/test/Clip.hs
@@ -7,7 +7,7 @@ d = unitSquare
     # fc red
     # clipBy clipPath
 
-clipPath :: Path R2
+clipPath :: Path V2 Double
 clipPath = polygonPath with {sides = 4} # scale (1/sqrt 2)
 
 main = defaultMain (pad 1.1 d)

--- a/test/Connect.hs
+++ b/test/Connect.hs
@@ -5,7 +5,7 @@ import Diagrams.Backend.Cairo.CmdLine
 
 import Data.Monoid
 
-type D = Diagram Cairo R2
+type D = Diagram Cairo V2 Double
 
 dot = circle 0.1
       # lw 0 # fc black

--- a/test/EllipseTest.hs
+++ b/test/EllipseTest.hs
@@ -24,7 +24,7 @@ newtype PlusMinusTwoPi = PlusMinusTwoPi Double
 
 data TEllipse = TEllipse [TStep] Ellipse
 
-mkTransformation :: [TStep] -> Transformation R2
+mkTransformation :: [TStep] -> Transformation V2 Double
 mkTransformation = mconcat . map step
   where
     step (Rotate     a) = rotation a
@@ -48,7 +48,7 @@ instance Arbitrary TSteps where
         y' <- arbitrary
         return [ Rotate a, ScaleX x, ScaleY y, TranslateX x', TranslateY y']
 
-instance Arbitrary (Transformation R2) where
+instance Arbitrary (Transformation V2 Double) where
     arbitrary = mkTransformation <$> arbitrary
 
 instance Arbitrary TEllipse where

--- a/test/FreezeTest.hs
+++ b/test/FreezeTest.hs
@@ -2,7 +2,7 @@ import Diagrams.Prelude
 
 import Diagrams.Backend.Cairo.CmdLine
 
-type D = Diagram Cairo R2
+type D = Diagram Cairo V2 Double
 
 s :: D
 s = unitSquare

--- a/test/PathTest.hs
+++ b/test/PathTest.hs
@@ -2,9 +2,9 @@ import Diagrams.Prelude
 
 import Diagrams.Backend.Cairo.CmdLine
 
-type D = AnnDiagram Cairo R2 Any
+type D = AnnDiagram Cairo V2 Double Any
 
-p :: Trail R2
+p :: Trail V2 Double
 p = fromOffsets [(1,2), (1,-5)]
 
 burst n = close . mconcat . take n . iterate (rotateBy (-1/(fromIntegral n))) $ p

--- a/test/SetBounds.hs
+++ b/test/SetBounds.hs
@@ -5,4 +5,4 @@ import Diagrams.Backend.Cairo.CmdLine
 
 main = defaultMain
          (circle 2 |||
-          square 1.5 # rotateBy (1/8) # withBounds (square 1 :: Diagram Cairo R2))
+          square 1.5 # rotateBy (1/8) # withBounds (square 1 :: Diagram Cairo V2 Double))

--- a/test/StrutTest.hs
+++ b/test/StrutTest.hs
@@ -3,7 +3,7 @@ import Diagrams.Prelude
 import Diagrams.Backend.Cairo
 import Diagrams.Backend.Cairo.CmdLine
 
-dia :: Diagram Cairo R2
+dia :: Diagram Cairo V2 Double
 dia = beside (1,0) unitCircle (beside (1,0) (strut (1,0)) unitCircle)
 
 main = defaultMain dia

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -2,7 +2,7 @@ import Diagrams.Prelude
 
 import Diagrams.Backend.Cairo.CmdLine
 
-type D = Diagram Cairo R2
+type D = Diagram Cairo V2 Double
 
 d = unitSquare `atop` unitCircle
     # lc red

--- a/test/beside.hs
+++ b/test/beside.hs
@@ -6,13 +6,13 @@ import Diagrams.Backend.Cairo.CmdLine
 
 import Diagrams.TwoD.Ellipse
 
-b :: (Backend b R2, Renderable Ellipse b, Renderable (Path R2) b) => Diagram b R2
+b :: (Backend b V2 Double, Renderable Ellipse b, Renderable (Path V2 Double) b) => Diagram b V2 Double
 b = beside (1,1) (rotate (pi/4 :: Rad) $ scaleY 2 unitCircle) unitSquare
 
-e1 :: (Backend b R2, Renderable Ellipse b, Renderable (Path R2) b) => Diagram b R2
+e1 :: (Backend b V2 Double, Renderable Ellipse b, Renderable (Path V2 Double) b) => Diagram b V2 Double
 e1 = rotate (pi/4 :: Rad) $ scaleY 2 unitCircle
 
-e2 :: (Backend b R2, Renderable Ellipse b, Renderable (Path R2) b) => Diagram b R2
+e2 :: (Backend b V2 Double, Renderable Ellipse b, Renderable (Path V2 Double) b) => Diagram b V2 Double
 e2 = translateX 1 $ e1
 
 main :: IO ()

--- a/test/path_bounds_bug.hs
+++ b/test/path_bounds_bug.hs
@@ -4,12 +4,12 @@ import Diagrams.Prelude
 
 import Diagrams.Backend.Cairo.CmdLine
 
-type D = Diagram Cairo R2
+type D = Diagram Cairo V2 Double
 
 t = (polygonPath with {sides = 3, orientation = OrientToX})
 [v1,v2] = trailOffsets t
 
-s :: Trail R2
+s :: Trail V2 Double
 s = fromSegments [Cubic v1 v1 (v1 ^+^ v2)]
 
 s1 = (strokeT $ s <> (rotateBy (1/3) s) <> (rotateBy (2/3) s))

--- a/test/path_resize.hs
+++ b/test/path_resize.hs
@@ -4,7 +4,7 @@ import Diagrams.Prelude
 import Diagrams.Backend.Cairo.CmdLine
 -- import Diagrams.Backend.Show
 
-type D = Diagram Cairo R2
+type D = Diagram Cairo V2 Double
 
 rule :: D
 rule = (strokeT $ fromOffsets [(1,0)])


### PR DESCRIPTION
`diagrams-cairo` remains specialized to Double, as is the `cairo`
package.  Rather than make many calls to `realToFrac`, we should provide
the necessary functions to map this or other functions over every
numeric value in a Diagram.

Only tested on GHC-7.8 so far.
