### PR TITLE
Bump lens upper version bounds

### DIFF
--- a/diagrams-cairo.cabal
+++ b/diagrams-cairo.cabal
@@ -58,7 +58,7 @@ Library
                        colour,
                        split >= 0.1.2 && < 0.3,
                        containers >= 0.3 && < 0.6,
-                       lens >= 3.8 && < 4.5,
+                       lens >= 3.8 && < 4.6,
                        data-default-class >= 0.0.1 && < 0.1,
                        statestack >= 0.2 && < 0.3,
                        JuicyPixels >= 3.1.3.2 && < 3.2,


### PR DESCRIPTION
Allow `diagrams-cairo` to use the latest version of `lens` (4.5).
