### PR TITLE
Reflection should be included in transformation returned by adjustDia

### DIFF
--- a/src/Diagrams/Backend/Cairo/Internal.hs
+++ b/src/Diagrams/Backend/Cairo/Internal.hs
@@ -163,7 +163,8 @@ instance Backend Cairo V2 Double where
 
   adjustDia c opts d = if _cairoBypassAdjust opts
                          then (opts, mempty, d # setDefault2DAttributes)
-                         else adjustDia2D cairoSizeSpec c opts (d # reflectY)
+                         else let (opts', transformation, d') = adjustDia2D cairoSizeSpec c opts (d # reflectY)
+                              in (opts', transformation <> reflectionY, d')
 
 runC :: Render Cairo V2 Double -> RenderM ()
 runC (C r) = r


### PR DESCRIPTION
Since we reflect the diagram, we need to apply the reflection in the transformation that adjustDia returns.