### PR TITLE
Export Cairo.Text module again. Also, introduce `DImage R Embedded`.

### DIFF
--- a/diagrams-cairo.cabal
+++ b/diagrams-cairo.cabal
@@ -68,6 +68,7 @@ Library
                        statestack >= 0.2 && < 0.3,
                        JuicyPixels >= 3.1.3.2 && < 3.3,
                        vector >= 0.10.0 && < 0.12,
+                       array >= 0.4.0 && < 0.6,
                        bytestring >= 0.9 && < 0.11,
                        optparse-applicative >= 0.10 && < 0.12,
                        transformers >= 0.3 && <0.5,

--- a/diagrams-cairo.cabal
+++ b/diagrams-cairo.cabal
@@ -51,6 +51,7 @@ Library
                        Diagrams.Backend.Cairo.Internal
                        Diagrams.Backend.Cairo.List
                        Diagrams.Backend.Cairo.Ptr
+                       Diagrams.Backend.Cairo.Text
   Hs-source-dirs:      src
   Build-depends:       base >= 4.2 && < 4.9,
                        mtl >= 2.0 && < 2.3,

--- a/src/Diagrams/Backend/Cairo/Internal.hs
+++ b/src/Diagrams/Backend/Cairo/Internal.hs
@@ -67,7 +67,6 @@ import           Data.List                       (isSuffixOf)
 import           Data.Maybe                      (catMaybes, fromMaybe, isJust)
 import           Data.Tree
 import           Data.Typeable
-import qualified Data.Vector.Storable            as VS
 import qualified Data.Array.MArray               as MA
 import           Data.Word                       (Word32)
 import           Data.Bits                       (rotateL, (.&.))

--- a/src/Diagrams/Backend/Cairo/Text.hs
+++ b/src/Diagrams/Backend/Cairo/Text.hs
@@ -1,0 +1,70 @@
+-- |
+-- Module      :  Diagrams.Backend.Cairo.Text
+-- Copyright   :  (c) 2015 Diagrams-cairo team (see LICENSE)
+-- License     :  BSD-style (see LICENSE)
+-- Maintainer  :  diagrams-discuss@googlegroups.com
+--
+-- This module provides convenience functions for querying information
+-- from cairo.  In particular, this provides utilities for information
+-- about fonts, and creating text primitives with bounds based on the
+-- font being used. To render text with automatically determined
+-- envelopes, use 'textLineBounded', 'textLineBoundedIO',
+-- 'textVisualBounded', or 'textVisualBoundedIO'.
+--
+-- Many of these functions take a 'Style' 'V2' 'Double' parameter,
+-- determining the style to apply to the text before rendering /
+-- querying information about the text.  These 'Style' 'V2' 'Double'
+-- parameters can be created a variety of ways, but the most direct
+-- will likely be by applying style-transforming functions such as
+-- 'font', 'fontSize', 'fontSlant', and 'fontWeight' to 'mempty'.
+-- This works because there are instances of 'HasStyle' and 'Monoid'
+-- for @'Style' v@.
+
+module Diagrams.Backend.Cairo.Text
+       (
+         -- | These create diagrams instantiated with extent-based envelopes.
+         textLineBoundedIO
+       , textVisualBoundedIO
+
+         -- * Utilities
+       , queryCairo, unsafeCairo
+       ) where
+
+import           Diagrams.Backend.Cairo.Internal
+import qualified Diagrams.BoundingBox            as BB
+import           Diagrams.Prelude                hiding (height, view)
+import           Diagrams.TwoD.Text              hiding (font)
+
+import qualified Graphics.Rendering.Cairo        as C
+import qualified Graphics.Rendering.Pango        as P
+
+import           System.IO.Unsafe
+
+-- | Executes a cairo action on a dummy, zero-size image surface, in order to
+--   query things like font information.
+queryCairo :: C.Render a -> IO a
+queryCairo c = C.withImageSurface C.FormatA1 0 0 (`C.renderWith` c)
+
+-- | Unsafely invokes 'queryCairo' using 'unsafePerformIO'.
+unsafeCairo :: C.Render a -> a
+unsafeCairo = unsafePerformIO . queryCairo
+
+-- | Creates text diagrams with their envelopes set such that using
+--   @'vcat' . map ('textLineBounded' style)@ stacks them in the way that
+--   the font designer intended.  Pango refers to this as logical extents.
+textLineBoundedIO :: Style V2 Double -> Text Double -> IO (Diagram Cairo)
+textLineBoundedIO = textLineIO fst
+
+-- | Creates a text diagram with its envelope set to enclose the glyphs of the text,
+--   including leading (though not trailing) whitespace.
+textVisualBoundedIO :: Style V2 Double -> Text Double -> IO (Diagram Cairo)
+textVisualBoundedIO = textLineIO snd
+
+-- | Abstract common code from @textLineBoundedIO@ and @textVisualBoundedIO@
+-- textLineIO :: ((a,a) -> a) -> Style V2 Double -> Text Double -> IO (Diagram Cairo)
+textLineIO :: ((P.PangoRectangle,P.PangoRectangle) -> P.PangoRectangle) -> Style V2 Double -> Text Double -> IO (Diagram Cairo)
+textLineIO pick sty txt = do
+    layout <- queryCairo $ layoutStyledText sty txt
+    P.PangoRectangle x y  w h <- pick <$> P.layoutGetExtents layout
+    let bb = BB.fromCorners (mkP2 x y) (mkP2 (x + w) (y + h))
+    return $ mkQD (Prim txt) (getEnvelope bb) mempty mempty mempty


### PR DESCRIPTION
As I said, the re-newed text module seems to work fine, at least for me.

Here's another thing: The Cairo backend can so far only do _external images_. However, raster graphics are actually quite straightforward in Cairo. The only problem is that [`Graphics.Rendering.Cairo.SurfaceData`](http://hackage.haskell.org/package/cairo-0.13.1.0/docs/Graphics-Rendering-Cairo.html#t:SurfaceData) is an abstract `MArray`, while [`Codec.Picture.Image`](http://hackage.haskell.org/package/JuicyPixels-3.2.5.3/docs/Codec-Picture.html#t:Image) uses `Vector.Storable`. Both aren't directly compatible, so I implemented the copying with a manual loop over the <del>bytes/pixel-components, which is of course inefficient and particularly annoying since both types are more or less just wrappers around C-arrays of exactly the same data!
So, this isn't really a good final implementation, but it does work ok. Any ideas how it could be done more efficiently, without getting too `unsafe`?</del>

It's still a loop now, but rather nicer: with the `ImageIPixels` traversal, over entire pixels (i.e. `Word32`). And it's probably necessary, because the data is in fact _not_ identical: JuicyPixels uses RGBA, while Cairo has ARGB, and one is big-endian, the other little-endian. So, effectively the red and blue channels are swapped; I implemented that with a `Data.Bits` rotation &ndash; probably quite optimal efficiency-wise.