### PR TITLE
compile with ghc-9.0.1

### DIFF
--- a/src/Diagrams/Backend/Cairo/CmdLine.hs
+++ b/src/Diagrams/Backend/Cairo/CmdLine.hs
@@ -110,6 +110,14 @@ import           Foreign.ForeignPtr              (ForeignPtr)
 
 import           Data.List.Split
 
+-- | Extra options for animated GIFs.
+data GifOpts = GifOpts { _dither     :: Bool
+                       , _noLooping  :: Bool
+                       , _loopRepeat :: Maybe Int}
+
+makeLenses ''GifOpts
+
+
 -- $mainwith
 -- The 'mainWith' method unifies all of the other forms of @main@ and is now
 -- the recommended way to build a command-line diagrams program.  It works as a
@@ -294,13 +302,6 @@ instance Mainable (Animation Cairo V2 Double) where
 -- @
 gifMain :: [(QDiagram Cairo V2 Double Any, GifDelay)] -> IO ()
 gifMain = mainWith
-
--- | Extra options for animated GIFs.
-data GifOpts = GifOpts { _dither     :: Bool
-                       , _noLooping  :: Bool
-                       , _loopRepeat :: Maybe Int}
-
-makeLenses ''GifOpts
 
 -- | Command line parser for 'GifOpts'.
 --   @--dither@ turn dithering on.


### PR DESCRIPTION
> https://downloads.haskell.org/ghc/9.0.1/docs/html/users_guide/9.0.1-notes.html
> It is no longer possible to use an instance of a class before a splice and define that instance after a splice