### PR TITLE
Build with `lens-5.2`

### DIFF
--- a/diagrams-cairo.cabal
+++ b/diagrams-cairo.cabal
@@ -63,7 +63,7 @@ Library
                        colour,
                        split >= 0.1.2 && < 0.3,
                        containers >= 0.3 && < 0.7,
-                       lens >= 3.8 && < 5.2,
+                       lens >= 3.8 && < 5.3,
                        data-default-class >= 0.0.1 && < 0.2,
                        statestack >= 0.2 && < 0.4,
                        JuicyPixels >= 3.1.3.2 && < 3.4,


### PR DESCRIPTION
Confirmed to build with `allow-newer: lens`