### PR TITLE
Allow `base < 4.18` to support GHC 9.4

### DIFF
--- a/diagrams-cairo.cabal
+++ b/diagrams-cairo.cabal
@@ -53,7 +53,7 @@ Library
                        Diagrams.Backend.Cairo.Ptr
                        Diagrams.Backend.Cairo.Text
   Hs-source-dirs:      src
-  Build-depends:       base >= 4.2 && < 4.17,
+  Build-depends:       base >= 4.2 && < 4.18,
                        mtl >= 2.0 && < 2.3,
                        filepath,
                        diagrams-core >= 1.3 && < 1.6,


### PR DESCRIPTION
Tested with GHC 9.4.5. It might be a good idea to add GHC 9.4 to the CI configuration as well.